### PR TITLE
WIP: Use normalized path as a file name

### DIFF
--- a/collection/file.go
+++ b/collection/file.go
@@ -47,12 +47,47 @@ func getString(m map[string]interface{}, key string) string {
 	return ""
 }
 
-func normalizeFileName(fname string) (nfname string) {
-	nfname = fname
-	if len(fname) > 255 {
-		nfname = nfname[len(fname)-255:]
+func first(s string, n int) string {
+	if len(s) < n {
+		n = len(s)
 	}
-	return strings.ReplaceAll(nfname, "/", "_")
+	return s[:n]
+}
+
+func last(s string, n int) string {
+	if len(s) < n {
+		n = len(s)
+	}
+	return s[len(s)-n:]
+}
+
+func splitExt(filePath string) (nameOnly, ext string) {
+	ext = path.Ext(filePath)
+	nameOnly = filePath[:len(filePath)-len(ext)-1]
+	return nameOnly, ext
+}
+
+func normalizeFilePath(filePath string) string {
+	maxLength := 64
+	maxSegmentLength := 4
+	filePath = strings.TrimLeft(filePath, "/")
+	pathSegments := strings.Split(filePath, "/")
+	normalizedFilePath := strings.Join(pathSegments, "_")
+
+	// get first 4 letters of every directory, while longer than maxLength
+	for i := 0; i < len(pathSegments)-1 && len(normalizedFilePath) > maxLength; i++ {
+		pathSegments[i] = first(pathSegments[i], maxSegmentLength)
+		normalizedFilePath = strings.Join(pathSegments, "_")
+	}
+
+	if len(normalizedFilePath) > maxLength {
+		// if still to long get first maxSegmentLength letters of filename + extension
+		nameOnly, ext := splitExt(pathSegments[len(pathSegments)-1])
+		pathSegments[len(pathSegments)-1] = first(nameOnly, maxSegmentLength) + ext
+		normalizedFilePath = strings.Join(pathSegments, "_")
+	}
+
+	return last(normalizedFilePath, maxLength)
 }
 
 func (c *LiveCollector) createFile(definitionName string, collectContents bool, srcpath, dstdir string) *goforensicstore.File {
@@ -88,7 +123,7 @@ func (c *LiveCollector) createFile(definitionName string, collectContents bool, 
 
 		// copy file
 		if collectContents && file.Size > 0 {
-			dstpath, storeFile, err := c.Store.StoreFile(filepath.Join(dstdir, normalizeFileName(srcpath)))
+			dstpath, storeFile, err := c.Store.StoreFile(filepath.Join(dstdir, normalizeFilePath(srcpath)))
 			if err != nil {
 				return file.AddError(errors.Wrap(err, "error storing file").Error())
 			}

--- a/collection/file.go
+++ b/collection/file.go
@@ -47,6 +47,14 @@ func getString(m map[string]interface{}, key string) string {
 	return ""
 }
 
+func normalizeFileName(fname string) (nfname string) {
+	nfname = fname
+	if len(fname) > 255 {
+		nfname = nfname[len(fname)-255:]
+	}
+	return strings.ReplaceAll(nfname, "/", "_")
+}
+
 func (c *LiveCollector) createFile(definitionName string, collectContents bool, srcpath, dstdir string) *goforensicstore.File {
 	file := &goforensicstore.File{}
 	file.Artifact = definitionName
@@ -80,7 +88,7 @@ func (c *LiveCollector) createFile(definitionName string, collectContents bool, 
 
 		// copy file
 		if collectContents && file.Size > 0 {
-			dstpath, storeFile, err := c.Store.StoreFile(filepath.Join(dstdir, path.Base(srcpath)))
+			dstpath, storeFile, err := c.Store.StoreFile(filepath.Join(dstdir, normalizeFileName(srcpath)))
 			if err != nil {
 				return file.AddError(errors.Wrap(err, "error storing file").Error())
 			}

--- a/collection/file_test.go
+++ b/collection/file_test.go
@@ -1,21 +1,57 @@
 package collection
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestNormalizeFileName(t *testing.T) {
+func TestNormalizeFilePath(t *testing.T) {
+	x32 := strings.Repeat("x", 32)
+	longFileName := strings.Repeat("long_file_name_", 8)
+
 	pathTests := []struct {
+		name              string
 		srcPath           string
 		normalizedSrcPath string
 	}{
-		{`/C/Users/user/NTUSER.DAT`, `_C_Users_user_NTUSER.DAT`},
-		{`/home/username/.bash_history`, `_home_username_.bash_history`},
-		{`/C/Users/user/AppData/Local/Google/Chrome/User Data/Default/Extensions/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/1.11_1/_metadata/folder_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name.json`, `ogle_Chrome_User Data_Default_Extensions_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_1.11_1__metadata_folder_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name.json`},
+		{"Windows path", `/C/Users/user/NTUSER.DAT`, `C_Users_user_NTUSER.DAT`},
+		{"Linux path", `/home/username/.bash_history`, `home_username_.bash_history`},
+		{
+			"Long path",
+			`/C/Users/user/AppData/Local/Google/Chrome/User Data/Default/Extensions/` + x32 + `/1.11_1/_metadata/folder_` + x32 + `/` + longFileName + `.json`,
+			`C_User_user_AppD_Loca_Goog_Chro_User_Defa_Exte_xxxx_1.11__met_fold_long.json`,
+		},
 	}
 
 	for _, pt := range pathTests {
-		got := normalizeFileName(pt.srcPath)
-		if got != pt.normalizedSrcPath {
-			t.Fatalf("need %v, got %v", pt.normalizedSrcPath, got)
-		}
+		t.Run(pt.name, func(t *testing.T) {
+			got := normalizeFilePath(pt.srcPath)
+
+			if got != pt.normalizedSrcPath {
+				t.Fatalf("need %v, got %v", pt.normalizedSrcPath, got)
+			}
+		})
+	}
+}
+
+func Test_last(t *testing.T) {
+	type args struct {
+		s string
+		n int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"long", args{"abcdef", 2}, "ef"},
+		{"short", args{"abc", 4}, "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := last(tt.args.s, tt.args.n); got != tt.want {
+				t.Errorf("last() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/collection/file_test.go
+++ b/collection/file_test.go
@@ -19,7 +19,7 @@ func TestNormalizeFilePath(t *testing.T) {
 		{
 			"Long path",
 			`/C/Users/user/AppData/Local/Google/Chrome/User Data/Default/Extensions/` + x32 + `/1.11_1/_metadata/folder_` + x32 + `/` + longFileName + `.json`,
-			`C_User_user_AppD_Loca_Goog_Chro_User_Defa_Exte_xxxx_1.11__met_fold_long.json`,
+			`AppD_Loca_Goog_Chro_User_Defa_Exte_xxxx_1.11__met_fold_long.json`,
 		},
 	}
 

--- a/collection/file_test.go
+++ b/collection/file_test.go
@@ -1,0 +1,21 @@
+package collection
+
+import "testing"
+
+func TestNormalizeFileName(t *testing.T) {
+	pathTests := []struct {
+		srcPath           string
+		normalizedSrcPath string
+	}{
+		{`/C/Users/user/NTUSER.DAT`, `_C_Users_user_NTUSER.DAT`},
+		{`/home/username/.bash_history`, `_home_username_.bash_history`},
+		{`/C/Users/user/AppData/Local/Google/Chrome/User Data/Default/Extensions/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/1.11_1/_metadata/folder_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name.json`, `ogle_Chrome_User Data_Default_Extensions_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_1.11_1__metadata_folder_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name_long_file_name.json`},
+	}
+
+	for _, pt := range pathTests {
+		got := normalizeFileName(pt.srcPath)
+		if got != pt.normalizedSrcPath {
+			t.Fatalf("need %v, got %v", pt.normalizedSrcPath, got)
+		}
+	}
+}


### PR DESCRIPTION
Hello,

On some artifacts collection (e.g. ChromeExtensions) it's hard to recognise what file was actually collected without looking at `items.db` contents.

What do you think about the idea that we can use normalised path as a resulting file name?