### PR TITLE
Add feature to specify output directory

### DIFF
--- a/collection/configuration.go
+++ b/collection/configuration.go
@@ -27,4 +27,5 @@ type Configuration struct {
 	Artifacts []string `yaml:"artifacts"`
 	User      bool     `yaml:"user"`
 	Case      string   `yaml:"case"`
+	OutputDir string   `yaml:"output_dir"`
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ import (
 //go:generate rsrc -arch 386 -manifest resources/artifactcollector32.exe.user.manifest -ico resources/artifactcollector.ico -o resources/artifactcollector32.user.syso
 
 func main() {
-	outDir := flag.String("o", "./", "Output directory for forensic store and log file")
+	outDir := flag.String("o", "./", "Output directory for forensicstore and log file")
 	flag.Parse()
 
 	var artifacts []goartifacts.ArtifactDefinition

--- a/main.go
+++ b/main.go
@@ -61,7 +61,9 @@ func main() {
 	artifacts = append(artifacts, assets.Artifacts...)
 
 	config := assets.Config
-	config.OutputDir = *outDir
+	if config.OutputDir == "" {
+		config.OutputDir = *outDir
+	}
 
 	collection := run.Run(config, artifacts, assets.FS)
 	if collection == nil {

--- a/main.go
+++ b/main.go
@@ -53,19 +53,18 @@ import (
 //go:generate rsrc -arch 386 -manifest resources/artifactcollector32.exe.user.manifest -ico resources/artifactcollector.ico -o resources/artifactcollector32.user.syso
 
 func main() {
-	outDir := flag.String("o", "./", "Output directory for forensicstore and log file")
+	outDir := flag.String("o", "", "Output directory for forensicstore and log file")
 	flag.Parse()
 
 	var artifacts []goartifacts.ArtifactDefinition
 	artifacts = append(artifacts, artifactsgo.Artifacts...)
 	artifacts = append(artifacts, assets.Artifacts...)
 
-	config := assets.Config
-	if config.OutputDir == "" {
-		config.OutputDir = *outDir
+	if *outDir != "" {
+		assets.Config.OutputDir = *outDir
 	}
 
-	collection := run.Run(config, artifacts, assets.FS)
+	collection := run.Run(assets.Config, artifacts, assets.FS)
 	if collection == nil {
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/forensicanalysis/artifactcollector/assets"
@@ -52,10 +53,17 @@ import (
 //go:generate rsrc -arch 386 -manifest resources/artifactcollector32.exe.user.manifest -ico resources/artifactcollector.ico -o resources/artifactcollector32.user.syso
 
 func main() {
+	outDir := flag.String("o", "./", "Output directory for forensic store and log file")
+	flag.Parse()
+
 	var artifacts []goartifacts.ArtifactDefinition
 	artifacts = append(artifacts, artifactsgo.Artifacts...)
 	artifacts = append(artifacts, assets.Artifacts...)
-	collection := run.Run(assets.Config, artifacts, assets.FS)
+
+	config := assets.Config
+	config.OutputDir = *outDir
+
+	collection := run.Run(config, artifacts, assets.FS)
 	if collection == nil {
 		os.Exit(1)
 	}

--- a/run/run.go
+++ b/run/run.go
@@ -67,7 +67,8 @@ func Run(config *collection.Configuration, artifactDefinitions []goartifacts.Art
 
 	// setup logging
 	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
-	logfile, logfileError := os.OpenFile(collectionName+".log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	logfilePath := filepath.Join(config.OutputDir, collectionName+".log")
+	logfile, logfileError := os.OpenFile(logfilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 	if logfileError != nil {
 		log.Printf("Could not open logfile %s\n", logfileError)
 	} else {
@@ -101,7 +102,8 @@ func Run(config *collection.Configuration, artifactDefinitions []goartifacts.Art
 	}
 
 	// create store
-	storeName, store, err := createStore(collectionName, config, artifactDefinitions)
+	collectionPath := filepath.Join(config.OutputDir, collectionName)
+	storeName, store, err := createStore(collectionPath, config, artifactDefinitions)
 	if err != nil {
 		logPrint(err)
 		return nil


### PR DESCRIPTION
Hi,

In some cases, e.g. collecting from multiple hosts in a centralized way, it can be handy to be able to specify output directory for stores and log files, so the analyst will get all reports in a single place, for example a network share.

Here's how it can be done with a flag parameter and a few changes.