### PR TITLE
Package collection tests for file.go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           go mod download
           go mod vendor
-          go generate
+          go generate -mod=vendor
           mv resources/artifactcollector32.syso artifactcollector.syso
         working-directory: repo
       - name: Build
@@ -123,7 +123,7 @@ jobs:
         run: |
           go mod download
           go mod vendor
-          go generate
+          go generate -mod=vendor
           mv resources/artifactcollector32.syso artifactcollector.syso
         working-directory: repo
       - name: Move packages

--- a/collection/file_test.go
+++ b/collection/file_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 Siemens AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Author(s): Jonas Plum
+
+package collection
+
+import (
+	"io"
+	"testing"
+)
+
+type storeWriterCloser struct{}
+
+func (s *storeWriterCloser) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+func (s *storeWriterCloser) Write(_ []byte) (int, error) {
+	return 0, nil
+}
+
+func (s *storeWriterCloser) Close() error {
+	return nil
+}
+
+func Test_getString(t *testing.T) {
+
+	testMap := map[string]interface{}{
+		"test": "I'm a string",
+	}
+
+	type args struct {
+		m   map[string]interface{}
+		key string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "key exists, value is a string",
+			args: args{
+				m:   testMap,
+				key: "test",
+			},
+			want: "I'm a string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getString(tt.args.m, tt.args.key); got != tt.want {
+				t.Errorf("getString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resetFile(t *testing.T) {
+	type args struct {
+		storeFile io.WriteCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "io.Seeker",
+			args: args{
+				storeFile: &storeWriterCloser{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resetFile(tt.args.storeFile); got != tt.want {
+				t.Errorf("resetFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/collection/file_test.go
+++ b/collection/file_test.go
@@ -58,7 +58,8 @@ func (s *storeSeeker) Seek(offset int64, whence int) (int64, error) {
 func Test_getString(t *testing.T) {
 
 	testMap := map[string]interface{}{
-		"test": "I'm a string",
+		"test":         "I'm a string",
+		"not a string": 1,
 	}
 
 	type args struct {
@@ -77,6 +78,14 @@ func Test_getString(t *testing.T) {
 				key: "test",
 			},
 			want: "I'm a string",
+		},
+		{
+			name: "key exists, not a string",
+			args: args{
+				m:   testMap,
+				key: "not a string",
+			},
+			want: "",
 		},
 	}
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.4.1
 	github.com/stoewer/go-strcase v1.2.0
-	golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,9 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b h1:lAZ0/chPUDWwjqosYR0X4M490zQhMsiJ4K3DbA7o+3g=
 golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
- Adding tests for `collection/file.go` (`getString`, `resetFile`, `hashCopy`).
- I would like to tackle testing the `LiveCollector.createFile(...)` method but I will open that in a separate PR.