### PR TITLE
docs: fix build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ generate-win: generate
 	rsrc -arch amd64 -manifest build/win/artifactcollector.exe.user.manifest -ico build/win/artifactcollector.ico -o build/win/artifactcollector.user.syso
 	rsrc -arch 386 -manifest build/win/artifactcollector32.exe.user.manifest -ico build/win/artifactcollector.ico -o build/win/artifactcollector32.user.syso
 
+.PHONY: build
+build: generate
+	@echo "Building..."
+	go build -o build/bin/artifactcollector .
+
 .PHONY: build-win
 build-win: generate-win
 	@echo "Building for Windows..."

--- a/README.md
+++ b/README.md
@@ -63,10 +63,8 @@ The zip file contains the results of the extraction and needs to be transferred 
 1. Clone the repository: `git clone https://github.com/forensicanalysis/artifactcollector`.
 2. Add and edit artifact definition yaml files as needed in `config/artifacts`.
 3. Edit `config/ac.yaml` and add the artifacts you want to collect.
-4. On windows, you can move the syso into the root folder (e.g. `cp resources\artifactcollector.syso .`)
-   to enable the icon for the executable and the UAC popup.
-5. Run `go build .` to generate the artifactcollector binary.
-   1. You can also use `GOOS=windows GOARCH=amd64 go build -o artifactcollector.exe .` to cross-compile for Windows.
+4. Run `make build` to generate the artifactcollector binary.
+   1. You can also use `make build-win` to cross-compile for Windows.
 
 ## Embed binaries
 


### PR DESCRIPTION
Current build instructions are missing the generate step